### PR TITLE
Add track 8 for main menus

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export type SettingsType = {
 	}
 	trackSource: keyof LangJson["audio"]["track-sources"]
 	autoMute: boolean
+	titleMusic: string
 
 	unlockEverything: boolean
 	

--- a/src/utils/AudioManager.ts
+++ b/src/utils/AudioManager.ts
@@ -359,11 +359,10 @@ observe(displayMode, 'screen', async (screen) => {
 })
 
 function muteOnTabSwitch() {
-  if (document.visibilityState == "hidden") {
-    if (settings.autoMute)
-      audio.masterVolume = 0
+  if (document.visibilityState == "hidden" && settings.autoMute) {
+    audio.masterVolume = 0
   }
-  else if (displayMode.screen == SCREEN.WINDOW) {
+  else {
     audio.masterVolume = settingToGain(settings.volume.master)
   }
 }

--- a/src/utils/AudioManager.ts
+++ b/src/utils/AudioManager.ts
@@ -164,7 +164,7 @@ class AudioManager {
     TSForceType<GainNode>(this.trackGainNode)
 
     if (!force && this.currentTrack == name)
-      return;
+      return
 
     if (this.trackNode) {
       this.trackNode.stop()
@@ -337,25 +337,24 @@ observe(settings, "trackSource", audio.resetBuffers.bind(audio))
 //_______________________________react to changes_______________________________
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-function playTrack(name: string) {
+observe(gameContext.audio, 'track', (name: string) => {
   if (name?.length > 0)
     audio.playTrack(name, true)
   else
     audio.stopTrack()
-}
-function loopSE(name: string) {
+})
+
+observe(gameContext.audio, 'looped_se', (name: string) => {
   if (name?.length > 0)
     audio.playSE(name, true)
   else
     audio.stopSE()
-}
-const windowFilter = { filter: () => displayMode.screen == SCREEN.WINDOW }
-observe(gameContext.audio, 'track', playTrack, windowFilter)
-observe(gameContext.audio, 'looped_se', loopSE, windowFilter)
+})
 
 observe(displayMode, 'screen', async (screen) => {
   if ([SCREEN.TITLE, SCREEN.LOAD, SCREEN.CONFIG, SCREEN.SCENES, SCREEN.ENDINGS, SCREEN.GALLERY].includes(screen)) {
-    audio.playTrack('"*8"', true, false);
+    audio.playTrack('"*8"', true, false)
+    audio.stopSE()
   }
 })
 

--- a/src/utils/AudioManager.ts
+++ b/src/utils/AudioManager.ts
@@ -337,15 +337,15 @@ observe(settings, "trackSource", audio.resetBuffers.bind(audio))
 //_______________________________react to changes_______________________________
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-observe(gameContext.audio, 'track', (name: string) => {
-  if (name?.length > 0)
+observe(gameContext.audio, 'track', (name: string|undefined) => {
+  if (name && name.length > 0)
     audio.playTrack(name, true)
   else
     audio.stopTrack()
 })
 
-observe(gameContext.audio, 'looped_se', (name: string) => {
-  if (name?.length > 0)
+observe(gameContext.audio, 'looped_se', (name: string|undefined) => {
+  if (name && name.length > 0)
     audio.playSE(name, true)
   else
     audio.stopSE()
@@ -353,17 +353,17 @@ observe(gameContext.audio, 'looped_se', (name: string) => {
 
 observe(displayMode, 'screen', async (screen) => {
   if ([SCREEN.TITLE, SCREEN.LOAD, SCREEN.CONFIG, SCREEN.SCENES, SCREEN.ENDINGS, SCREEN.GALLERY].includes(screen)) {
-    audio.playTrack('"*8"', true, false)
+    audio.playTrack(settings.titleMusic, true, false)
     audio.stopSE()
   }
 })
 
 function muteOnTabSwitch() {
-  if (document.visibilityState == "hidden" && settings.autoMute) {
-    audio.masterVolume = 0
-  }
-  else {
-    audio.masterVolume = settingToGain(settings.volume.master)
+  if (settings.autoMute) {
+    if (document.visibilityState == "hidden")
+      audio.masterVolume = 0
+    else
+      audio.masterVolume = settingToGain(settings.volume.master)
   }
 }
 

--- a/src/utils/AudioManager.ts
+++ b/src/utils/AudioManager.ts
@@ -155,12 +155,16 @@ class AudioManager {
    * by the specified one. Fetch the audio buffer if necessary.
    * @param name name of the track to play.
    * @param loop true if the track must be looped when it reaches the end
+   * @param force true if the track must be restarted if it we are already playing this track
    *             of the audio buffer, false otherwise. Defaults to true.
    */
-  async playTrack(name: string, loop = true): Promise<void> {
+  async playTrack(name: string, loop = true, force = true): Promise<void> {
     this.buildNodes()
     TSForceType<AudioContext>(this.context)
     TSForceType<GainNode>(this.trackGainNode)
+
+    if (!force && this.currentTrack == name)
+      return;
 
     if (this.trackNode) {
       this.trackNode.stop()
@@ -349,18 +353,10 @@ const windowFilter = { filter: () => displayMode.screen == SCREEN.WINDOW }
 observe(gameContext.audio, 'track', playTrack, windowFilter)
 observe(gameContext.audio, 'looped_se', loopSE, windowFilter)
 
-observe(displayMode, 'screen', (screen)=> {
-  if (screen == SCREEN.WINDOW) {
-    const {track, looped_se} = gameContext.audio
-    playTrack(track)
-    loopSE(looped_se)
-    // audio.masterVolume = settingToGain(settings.volume.master)
-  } else {
-    playTrack('')
-    loopSE('')
-    // audio.masterVolume = 0
+observe(displayMode, 'screen', async (screen) => {
+  if ([SCREEN.TITLE, SCREEN.LOAD, SCREEN.CONFIG, SCREEN.SCENES, SCREEN.ENDINGS, SCREEN.GALLERY].includes(screen)) {
+    audio.playTrack('"*8"', true, false);
   }
-  // uncomment masterVolume changes if game sound keeps playing on title menu
 })
 
 function muteOnTabSwitch() {
@@ -380,9 +376,9 @@ function settingToGain(value: number) {
     return 0
   const valueRange = 10 // from 0 to 10. 0 => no sound.
   const dbRange = 25 // from -25dB to 0dB. -25 not used (volume=0 => no sound).
-  const normalizedValue = value/valueRange
-  const dB = normalizedValue*dbRange - dbRange
-  return Math.pow(10, dB/20)
+  const normalizedValue = value / valueRange
+  const dB = normalizedValue * dbRange - dbRange
+  return Math.pow(10, dB / 20)
 }
 
 audio.masterVolume = settingToGain(settings.volume.master)

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -19,7 +19,7 @@ let savesVariant: 'save'|'load'|'' = '';
 let config: boolean = false;
 
 export const displayMode: { [key: string]: any } = {
-  screen: SCREEN.TITLE,
+  screen: undefined,
   menu: false as boolean,
   bgAlignment: 'center' as ('top' | 'center' | 'bottom'),
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -28,6 +28,7 @@ export const defaultSettings: SettingsType = deepFreeze({
   },
   trackSource: 'everafter',
   autoMute: true,
+  titleMusic: '"*8"',
 
   unlockEverything: false,
   

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -24,8 +24,8 @@ const [gameContext, resetContext, defaultGameContext] = resettable(deepFreeze({
 //_______________________________audio, graphics________________________________
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   audio: {
-    track: '"*8"',
-    looped_se: "",
+    track: undefined,
+    looped_se: undefined,
   },
   graphics: {
     bg: "",

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -24,8 +24,8 @@ const [gameContext, resetContext, defaultGameContext] = resettable(deepFreeze({
 //_______________________________audio, graphics________________________________
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   audio: {
-    track: undefined,
-    looped_se: undefined,
+    track: undefined as string|undefined,
+    looped_se: undefined as string|undefined,
   },
   graphics: {
     bg: "",

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -24,7 +24,7 @@ const [gameContext, resetContext, defaultGameContext] = resettable(deepFreeze({
 //_______________________________audio, graphics________________________________
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   audio: {
-    track: "",
+    track: '"*8"',
     looped_se: "",
   },
   graphics: {


### PR DESCRIPTION
Hello,

Here are the change for this commit:

- add the track 8 for the following menus:
    - SCREEN.TITLE
    - SCREEN.LOAD
    - SCREEN.CONFIG
    - SCREEN.SCENES
    - SCREEN.ENDINGS
    - SCREEN.GALLERY
- update tsukiweb-common to the latest commit.

Notice that if we hit F5 on of these menu and do nothing, chrome doesn't allow us to play automatically the track if we don't interact with the UI.

https://developer.chrome.com/blog/autoplay/#webaudio