### PR TITLE
Use range input instead of select for the text speed

### DIFF
--- a/src/components/config/ConfigGameTab.tsx
+++ b/src/components/config/ConfigGameTab.tsx
@@ -80,7 +80,7 @@ const ConfigGameTab = () => {
 						step={TEXT_SPEED_STEP_WIDTH}
 						value={conf.textSpeed}
 						onChange={e => {
-							updateValue('textSpeed', parseInt(e.target.value)); console.log(e.target.value, TextSettingsToCharacterDelay(parseInt(e.target.value)))
+							updateValue('textSpeed', TextSettingsToCharacterDelay(parseInt(e.target.value)))
 						}} />
 					<span className="icon"><FaPlus /></span>
 				</div>

--- a/src/components/config/ConfigGameTab.tsx
+++ b/src/components/config/ConfigGameTab.tsx
@@ -6,7 +6,7 @@ import { getLocale, strings } from "../../translation/lang"
 import { useLanguageRefresh } from "../hooks/useLanguageRefresh"
 import PageSection from "@tsukiweb-common/ui-core/layouts/PageSection"
 import { deepAssign, isFullscreen, toggleFullscreen, addEventListener } from "@tsukiweb-common/utils/utils"
-import { ViewRatio, TEXT_SPEED } from "@tsukiweb-common/constants"
+import { TEXT_SPEED_MAX, TEXT_SPEED_STEP_WIDTH, TextSettingsToCharacterDelay, ViewRatio } from "@tsukiweb-common/constants"
 
 const ConfigGameTab = () => {
 	useLanguageRefresh()
@@ -70,18 +70,21 @@ const ConfigGameTab = () => {
 				updateValue={toggleFullscreen}
 			/>
 
-			<ConfigButtons
-				title={strings.config["text-speed"]}
-				btns={[
-					{ text: strings.config["text-speed-low"], value: TEXT_SPEED.slow },
-					{ text: strings.config["text-speed-med"], value: TEXT_SPEED.normal },
-					{ text: strings.config["text-speed-high"], value: TEXT_SPEED.fast },
-					{ text: strings.config["text-speed-instant"], value: TEXT_SPEED.instant }
-				]}
-				property="textSpeed"
-				conf={conf}
-				updateValue={updateValue}
-			/>
+			<ConfigItem title={strings.config["text-speed"]}>
+				<div className="config-range">
+					<span className="icon"><FaMinus /></span>
+					<input
+						type="range"
+						min={0}
+						max={TEXT_SPEED_MAX}
+						step={TEXT_SPEED_STEP_WIDTH}
+						value={conf.textSpeed}
+						onChange={e => {
+							updateValue('textSpeed', parseInt(e.target.value)); console.log(e.target.value, TextSettingsToCharacterDelay(parseInt(e.target.value)))
+						}} />
+					<span className="icon"><FaPlus /></span>
+				</div>
+			</ConfigItem>
 
 			<ConfigItem title={strings.config["auto-play-delay-text"].replace('$0',msToS(conf.autoClickDelay))}>
 				<div className="config-range">

--- a/src/components/config/ConfigGameTab.tsx
+++ b/src/components/config/ConfigGameTab.tsx
@@ -80,7 +80,7 @@ const ConfigGameTab = () => {
 						step={TEXT_SPEED_STEP_WIDTH}
 						value={conf.textSpeed}
 						onChange={e => {
-							updateValue('textSpeed', TextSettingsToCharacterDelay(parseInt(e.target.value)))
+							updateValue('textSpeed', parseInt(e.target.value))
 						}} />
 					<span className="icon"><FaPlus /></span>
 				</div>

--- a/src/layers/TextLayer.tsx
+++ b/src/layers/TextLayer.tsx
@@ -9,6 +9,7 @@ import useMousePointer from "@tsukiweb-common/hooks/useMousePointer"
 import { observe, useObserved, useObserver } from "@tsukiweb-common/utils/Observer"
 import { DivProps } from "@tsukiweb-common/types"
 import { Bbcode, BBTypeWriter } from "@tsukiweb-common/utils/Bbcode"
+import { TextSettingsToCharacterDelay } from "@tsukiweb-common/constants"
 
 export const icons: Record<"moon"|"page", string> = {
   "moon": moonIcon,
@@ -66,7 +67,7 @@ const TextLayer = ({...props}: Props) => {
 
         {lastLine ?
           <BBTypeWriter key={history.length*100 + lines.length}
-            charDelay={immediate ? 0 : settings.textSpeed}
+            charDelay={immediate ? 0 : TextSettingsToCharacterDelay(settings.textSpeed)}
             text={lastLine}
             hideTag="hide"
             onFinish={()=> { scriptInterface.onFinish?.() }}

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -3,10 +3,10 @@ import { SettingsType } from "../types"
 import { observeChildren, observe } from "@tsukiweb-common/utils/Observer"
 import { StoredJSON } from "@tsukiweb-common/utils/storage"
 import { deepFreeze, deepAssign, jsonDiff, objectsEqual } from "@tsukiweb-common/utils/utils"
-import { TEXT_SPEED, ViewRatio } from "@tsukiweb-common/constants"
+import { ViewRatio } from "@tsukiweb-common/constants"
 
 export const defaultSettings: SettingsType = deepFreeze({
-  textSpeed: TEXT_SPEED.normal,
+  textSpeed: 1000,
   autoClickDelay: 500,
   nextPageDelay: 2500,
   fastForwardDelay: 5,


### PR DESCRIPTION
Implement the change described in https://github.com/requinDr/tsukiweb-common/pull/3

Notice there is a breaking change in the config save value. We now have a value between 0-3000 for the text speed instead of 0-3 (enum)

Best
Raphaël