### PR TITLE
Lightened innactive flowchart connections

### DIFF
--- a/src/features/flowchart/styles/flowchart.scss
+++ b/src/features/flowchart/styles/flowchart.scss
@@ -15,7 +15,7 @@
 	overscroll-behavior: contain;
 	touch-action: pan-x pan-y;
 	--active-connection: #0d96e0;
-	--inactive-connection: #444;
+	--inactive-connection: #888;
 
 	.flowchart {
 		flex: none;


### PR DESCRIPTION
It's honestly pretty difficult to see where the inactive lines lead sometimes. It's really dark against the background.
<img width="1920" height="1080" alt="flowchart-1" src="https://github.com/user-attachments/assets/c3c546e1-93f6-40fd-80c0-548946ff682e" />
<img width="1920" height="1080" alt="flowchart-2" src="https://github.com/user-attachments/assets/0757d109-ef3b-421c-aa13-34ab1afc3dd9" />
